### PR TITLE
update CDO and add classes

### DIFF
--- a/CDO/crystallographic-defect-ontology.owl
+++ b/CDO/crystallographic-defect-ontology.owl
@@ -1,4 +1,4 @@
-<?xml version="1.1"?>
+<?xml version="1.0"?>
 <rdf:RDF xmlns="https://purls.helmholtz-metadaten.de/disos/cdo"
      xml:base="https://purls.helmholtz-metadaten.de/disos/cdo"
      xmlns:owl="http://www.w3.org/2002/07/owl#"
@@ -151,6 +151,14 @@
     
 
 
+    <!-- https://purls.helmholtz-metadaten.de/disos/cdo#BulkDefect -->
+
+    <owl:Class rdf:about="https://purls.helmholtz-metadaten.de/disos/cdo#BulkDefect">
+        <rdfs:subClassOf rdf:resource="https://purls.helmholtz-metadaten.de/disos/cdo#CrystallographicDefect"/>
+    </owl:Class>
+    
+
+
     <!-- https://purls.helmholtz-metadaten.de/disos/cdo#CrystallineMaterial -->
 
     <owl:Class rdf:about="https://purls.helmholtz-metadaten.de/disos/cdo#CrystallineMaterial">
@@ -208,9 +216,9 @@
     
 
 
-    <!-- https://purls.helmholtz-metadaten.de/disos/cdo#GrainBoundary -->
+    <!-- https://purls.helmholtz-metadaten.de/disos/cdo#PlaneDefect -->
 
-    <owl:Class rdf:about="https://purls.helmholtz-metadaten.de/disos/cdo#GrainBoundary">
+    <owl:Class rdf:about="https://purls.helmholtz-metadaten.de/disos/cdo#PlaneDefect">
         <rdfs:subClassOf rdf:resource="https://purls.helmholtz-metadaten.de/disos/cdo#CrystallographicDefect"/>
     </owl:Class>
     

--- a/DISO/CQs/CQs_v1_1.md
+++ b/DISO/CQs/CQs_v1_1.md
@@ -340,6 +340,7 @@ PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX mdo_prov: <https://w3id.org/mdo/provenance/>
 PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 PREFIX mwo: <http://purls.helmholtz-metadaten.de/mwo/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
 SELECT ?dislocationstructure ?software_name ?soft_version ?data_creator_first_name ?data_creator_last_name ?data_creator_orcid WHERE{
     ?dislocationsimulation diso:hasOutputDislocationStructure ?dislocationstructure.


### PR DESCRIPTION
This PR solves #9

- removed `GrainBoundary` class
- added `BulkDefect`, `LineDefect`, `PlaneDefect`
- `Dislocation` is now a subclass of `LineDefect` -> Just to make a bit equal in the organization of the defect.
- As I studied again about EMMO, I changed `EMMO:Material` with `EMMO:Solid`. The class will be a super-class of `CrystallineMaterial` 
